### PR TITLE
[account_move_template] add partner to the template

### DIFF
--- a/account_move_template/models/account_move_template.py
+++ b/account_move_template/models/account_move_template.py
@@ -46,6 +46,7 @@ class AccountMoveTemplateLine(models.Model):
         required=True,
         ondelete="cascade"
     )
+    partner_id = fields.Many2one('res.partner', string='Partner')
     move_line_type = fields.Selection(
         [('cr', 'Credit'), ('dr', 'Debit')],
         required=True

--- a/account_move_template/view/move_template.xml
+++ b/account_move_template/view/move_template.xml
@@ -8,10 +8,11 @@
                 <field name="sequence"/>
                 <field name="name"/>
                 <field name="journal_id"/>
-                <field name="account_id" />
+                <field name="account_id"/>
+                <field name="partner_id"/>
                 <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
                 <field name="type"/>
-                <field name="python_code" />
+                <field name="python_code"/>
                 <field name="move_line_type"/>
             </tree>
         </field>
@@ -29,6 +30,7 @@
                             <field name="sequence"/>
                             <field name="journal_id"/>
                             <field name="account_id"/>
+                            <field name="partner_id"/>
                             <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
                         </group>
                         <group>

--- a/account_move_template/wizard/select_template.xml
+++ b/account_move_template/wizard/select_template.xml
@@ -35,10 +35,11 @@
             <form string="Move Template Line">
                 <group>
                     <field name="sequence" invisible="1"/>
-                    <field name="name" />
-                    <field name="account_id" />
-                    <field name="move_line_type" />
-                    <field name="amount" />
+                    <field name="name"/>
+                    <field name="account_id"/>
+                    <field name="partner_id"/>
+                    <field name="move_line_type"/>
+                    <field name="amount"/>
                 </group>
             </form>
         </field>
@@ -50,8 +51,9 @@
         <field name="arch" type="xml">
             <tree editable="bottom">
                 <field name="sequence" invisible="1"/>
-                <field name="name" />
-                <field name="account_id" />
+                <field name="name"/>
+                <field name="account_id"/>
+                <field name="partner_id"/>
                 <field name="move_line_type" />
                 <field name="amount" />
             </tree>


### PR DESCRIPTION
This is an interesting added feature. Adds the capability to indicate the partner to the template.

As of v10 or v11, the partner is no longer shown in the account.move. Makes no sense to assign it there.